### PR TITLE
Add days-left widget and CloudKit tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Widgeme
+
+This project is a simple SwiftUI application showcasing a widget that tells you
+how many days are left in the year. The app also includes a very small
+`HabitTracker` class which can store daily check‑ins using CloudKit.
+
+### Widget
+
+The widget (`DaysLeftWidget`) displays the remaining days in the current year.
+It refreshes automatically every day.
+
+### Habit Tracking
+
+`HabitTracker` provides a starting point for storing completed days in
+CloudKit. Each time the **Mark Today Complete** button is tapped the day is
+recorded.
+
+This repository only contains the Swift source files. You may need to open the
+`Widgeme.xcodeproj` in Xcode and add a widget extension target to build the
+widget on a device or simulator.

--- a/Widgeme/Widgeme/ContentView.swift
+++ b/Widgeme/Widgeme/ContentView.swift
@@ -6,14 +6,20 @@
 //
 
 import SwiftUI
+import CloudKit
 
 struct ContentView: View {
+    @StateObject private var tracker = HabitTracker()
+
     var body: some View {
-        VStack {
-            Image(systemName: "lobe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(spacing: 16) {
+            Text("\(Date().daysLeftInYear()) days left in the year")
+                .font(.headline)
+
+            Button("Mark Today Complete") {
+                tracker.mark(date: Date(), completed: true)
+            }
+            .buttonStyle(.borderedProminent)
         }
         .padding()
     }

--- a/Widgeme/Widgeme/Date+DaysLeft.swift
+++ b/Widgeme/Widgeme/Date+DaysLeft.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension Date {
+    func daysLeftInYear() -> Int {
+        let calendar = Calendar.current
+        let current = calendar.startOfDay(for: self)
+        guard let startOfNextYear = calendar.date(from: DateComponents(year: calendar.component(.year, from: current) + 1)) else {
+            return 0
+        }
+        return calendar.dateComponents([.day], from: current, to: startOfNextYear).day ?? 0
+    }
+}

--- a/Widgeme/Widgeme/HabitTracker.swift
+++ b/Widgeme/Widgeme/HabitTracker.swift
@@ -1,0 +1,32 @@
+import CloudKit
+import Foundation
+
+struct HabitRecord {
+    let id: CKRecord.ID
+    let date: Date
+    let completed: Bool
+}
+
+class HabitTracker: ObservableObject {
+    private let container: CKContainer
+    private var database: CKDatabase { container.privateCloudDatabase }
+
+    @Published var records: [HabitRecord] = []
+
+    init(container: CKContainer = .default()) {
+        self.container = container
+    }
+
+    func mark(date: Date, completed: Bool) {
+        let record = CKRecord(recordType: "Habit")
+        record["date"] = date as NSDate
+        record["completed"] = completed as NSNumber
+        database.save(record) { [weak self] record, error in
+            guard let record = record, error == nil else { return }
+            let item = HabitRecord(id: record.recordID, date: date, completed: completed)
+            DispatchQueue.main.async {
+                self?.records.append(item)
+            }
+        }
+    }
+}

--- a/Widgeme/WidgemeWidget/DaysLeftWidget.swift
+++ b/Widgeme/WidgemeWidget/DaysLeftWidget.swift
@@ -1,0 +1,57 @@
+import WidgetKit
+import SwiftUI
+
+struct DaysLeftEntry: TimelineEntry {
+    let date: Date
+    let daysLeft: Int
+}
+
+struct DaysLeftProvider: TimelineProvider {
+    func placeholder(in context: Context) -> DaysLeftEntry {
+        DaysLeftEntry(date: .now, daysLeft: Date().daysLeftInYear())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (DaysLeftEntry) -> Void) {
+        completion(placeholder(in: context))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<DaysLeftEntry>) -> Void) {
+        let entry = DaysLeftEntry(date: .now, daysLeft: Date().daysLeftInYear())
+        // Refresh at midnight
+        let nextUpdate = Calendar.current.startOfDay(for: .now).addingTimeInterval(86400)
+        completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+    }
+}
+
+struct DaysLeftWidgetEntryView: View {
+    var entry: DaysLeftProvider.Entry
+
+    var body: some View {
+        VStack {
+            Text("\(entry.daysLeft)")
+                .font(.largeTitle)
+            Text("days left in the year")
+                .font(.caption)
+        }
+    }
+}
+
+struct DaysLeftWidget: Widget {
+    let kind = "DaysLeftWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: DaysLeftProvider()) { entry in
+            DaysLeftWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Days Left")
+        .description("Shows how many days are left in the year.")
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+@main
+struct DaysLeftWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        DaysLeftWidget()
+    }
+}


### PR DESCRIPTION
## Summary
- show how many days are left in the year
- add HabitTracker CloudKit helper
- sketch basic widget that displays the remaining days
- document how the app and widget work

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a153778088326acb4b1b1c3bb772c