### PR TITLE
Add habit management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ It refreshes automatically every day.
 ### Habit Tracking
 
 `HabitTracker` provides a starting point for storing completed days in
-CloudKit. Each time the **Mark Today Complete** button is tapped the day is
-recorded.
+CloudKit. You can now add custom habits and mark each one complete for the
+current day. Each check-in is saved to CloudKit so your progress syncs across
+devices.
 
 This repository only contains the Swift source files. You may need to open the
 `Widgeme.xcodeproj` in Xcode and add a widget extension target to build the

--- a/Widgeme/Widgeme/ContentView.swift
+++ b/Widgeme/Widgeme/ContentView.swift
@@ -10,18 +10,40 @@ import CloudKit
 
 struct ContentView: View {
     @StateObject private var tracker = HabitTracker()
+    @State private var newHabit = ""
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text("\(Date().daysLeftInYear()) days left in the year")
-                .font(.headline)
+        NavigationView {
+            VStack(spacing: 16) {
+                Text("\(Date().daysLeftInYear()) days left in the year")
+                    .font(.headline)
 
-            Button("Mark Today Complete") {
-                tracker.mark(date: Date(), completed: true)
+                HStack {
+                    TextField("New Habit", text: $newHabit)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Add") {
+                        tracker.addHabit(name: newHabit)
+                        newHabit = ""
+                    }
+                    .disabled(newHabit.isEmpty)
+                }
+
+                List {
+                    ForEach(tracker.habits, id: \.id) { habit in
+                        HStack {
+                            Text(habit.name)
+                            Spacer()
+                            Button("Mark Today") {
+                                tracker.mark(habit: habit, date: Date(), completed: true)
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                    }
+                }
             }
-            .buttonStyle(.borderedProminent)
+            .padding()
+            .navigationTitle("Positive Habits")
         }
-        .padding()
     }
 }
 

--- a/Widgeme/Widgeme/HabitTracker.swift
+++ b/Widgeme/Widgeme/HabitTracker.swift
@@ -1,8 +1,14 @@
 import CloudKit
 import Foundation
 
+struct PositiveHabit {
+    let id: CKRecord.ID
+    let name: String
+}
+
 struct HabitRecord {
     let id: CKRecord.ID
+    let habitID: CKRecord.ID
     let date: Date
     let completed: Bool
 }
@@ -11,19 +17,33 @@ class HabitTracker: ObservableObject {
     private let container: CKContainer
     private var database: CKDatabase { container.privateCloudDatabase }
 
+    @Published var habits: [PositiveHabit] = []
     @Published var records: [HabitRecord] = []
 
     init(container: CKContainer = .default()) {
         self.container = container
     }
 
-    func mark(date: Date, completed: Bool) {
-        let record = CKRecord(recordType: "Habit")
+    func addHabit(name: String) {
+        let record = CKRecord(recordType: "PositiveHabit")
+        record["name"] = name as NSString
+        database.save(record) { [weak self] record, error in
+            guard let record = record, error == nil else { return }
+            let habit = PositiveHabit(id: record.recordID, name: name)
+            DispatchQueue.main.async {
+                self?.habits.append(habit)
+            }
+        }
+    }
+
+    func mark(habit: PositiveHabit, date: Date, completed: Bool) {
+        let record = CKRecord(recordType: "HabitRecord")
+        record["habit"] = CKRecord.Reference(recordID: habit.id, action: .none)
         record["date"] = date as NSDate
         record["completed"] = completed as NSNumber
         database.save(record) { [weak self] record, error in
             guard let record = record, error == nil else { return }
-            let item = HabitRecord(id: record.recordID, date: date, completed: completed)
+            let item = HabitRecord(id: record.recordID, habitID: habit.id, date: date, completed: completed)
             DispatchQueue.main.async {
                 self?.records.append(item)
             }


### PR DESCRIPTION
## Summary
- add `PositiveHabit` model and update `HabitTracker` to save habits and records
- update `ContentView` to allow creating habits and marking them complete
- document new habit features in `README`

## Testing
- `swift --version`
- `swiftc -parse Widgeme/Widgeme/ContentView.swift Widgeme/Widgeme/Date+DaysLeft.swift Widgeme/Widgeme/HabitTracker.swift Widgeme/Widgeme/WidgemeApp.swift`

------
https://chatgpt.com/codex/tasks/task_e_684a1864ffc48326b3d4eebc0e8f4e84