### PR TITLE
Add habit progress widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # Widgeme
 
-This project is a simple SwiftUI application showcasing a widget that tells you
-how many days are left in the year. The app also includes a very small
-`HabitTracker` class which can store daily check‑ins using CloudKit.
+This project is a simple SwiftUI application showcasing two widgets. The first
+widget counts down the days left in the year. A second "Habit Progress" widget
+displays your positive habit completions for the current week. The app also
+includes a small `HabitTracker` class which can store daily check‑ins using
+CloudKit.
 
 ### Widget
 
-The widget (`DaysLeftWidget`) displays the remaining days in the current year.
-It refreshes automatically every day.
+The `DaysLeftWidget` displays the remaining days in the current year and
+refreshes automatically every day. The `HabitProgressWidget` shows a single
+habit with checkmarks for the last seven days so you can glance at your recent
+streaks right from the home screen.
 
 ### Habit Tracking
 

--- a/Widgeme/WidgemeWidget/DaysLeftWidget.swift
+++ b/Widgeme/WidgemeWidget/DaysLeftWidget.swift
@@ -50,8 +50,9 @@ struct DaysLeftWidget: Widget {
 }
 
 @main
-struct DaysLeftWidgetBundle: WidgetBundle {
+struct WidgemeWidgetBundle: WidgetBundle {
     var body: some Widget {
         DaysLeftWidget()
+        HabitProgressWidget()
     }
 }

--- a/Widgeme/WidgemeWidget/HabitProgressWidget.swift
+++ b/Widgeme/WidgemeWidget/HabitProgressWidget.swift
@@ -1,0 +1,76 @@
+import WidgetKit
+import SwiftUI
+import CloudKit
+import Widgeme
+
+struct HabitProgressEntry: TimelineEntry {
+    let date: Date
+    let habitName: String
+    let completions: [Date]
+}
+
+struct HabitProgressProvider: TimelineProvider {
+    func placeholder(in context: Context) -> HabitProgressEntry {
+        HabitProgressEntry(date: .now, habitName: "Meditation", completions: [])
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (HabitProgressEntry) -> Void) {
+        completion(placeholder(in: context))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<HabitProgressEntry>) -> Void) {
+        let tracker = HabitTracker()
+        tracker.fetchHabits { habits in
+            guard let habit = habits.first else {
+                completion(Timeline(entries: [placeholder(in: context)], policy: .never))
+                return
+            }
+            tracker.fetchRecords(for: habit) { records in
+                let end = Calendar.current.startOfDay(for: Date())
+                let start = Calendar.current.date(byAdding: .day, value: -6, to: end) ?? end
+                let completions = records.filter { $0.completed && $0.date >= start && $0.date <= end }
+                    .map { Calendar.current.startOfDay(for: $0.date) }
+                let entry = HabitProgressEntry(date: .now, habitName: habit.name, completions: completions)
+                let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: .now) ?? .now
+                completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+            }
+        }
+    }
+}
+
+struct HabitProgressWidgetEntryView: View {
+    var entry: HabitProgressProvider.Entry
+    private var days: [Date] {
+        let today = Calendar.current.startOfDay(for: entry.date)
+        let start = Calendar.current.date(byAdding: .day, value: -6, to: today) ?? today
+        return (0..<7).compactMap { Calendar.current.date(byAdding: .day, value: $0, to: start) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(entry.habitName)
+                .font(.headline)
+            HStack(spacing: 4) {
+                ForEach(days, id: \.self) { day in
+                    let done = entry.completions.contains { Calendar.current.isDate($0, inSameDayAs: day) }
+                    Image(systemName: done ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(done ? .green : .gray)
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+struct HabitProgressWidget: Widget {
+    let kind = "HabitProgressWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: HabitProgressProvider()) { entry in
+            HabitProgressWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Habit Progress")
+        .description("Shows your habit completions for the week.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}


### PR DESCRIPTION
## Summary
- add Habit Progress widget extension
- make widget bundle host both days-left and habit progress widgets
- expose CloudKit fetch APIs for habits and records
- document new widget in README

## Testing
- `swiftc -parse Widgeme/WidgemeWidget/HabitProgressWidget.swift`
- `swiftc -parse Widgeme/WidgemeWidget/DaysLeftWidget.swift`
- `swiftc -parse Widgeme/Widgeme/HabitTracker.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684a19abf3bc832682339b42a73e0421