### PR TITLE
Add habit calendar grid

### DIFF
--- a/Widgeme/Widgeme/ContentView.swift
+++ b/Widgeme/Widgeme/ContentView.swift
@@ -30,19 +30,29 @@ struct ContentView: View {
 
                 List {
                     ForEach(tracker.habits, id: \.id) { habit in
-                        HStack {
-                            Text(habit.name)
-                            Spacer()
-                            Button("Mark Today") {
-                                tracker.mark(habit: habit, date: Date(), completed: true)
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text(habit.name)
+                                Spacer()
+                                Button("Mark Today") {
+                                    tracker.mark(habit: habit, date: Date(), completed: true)
+                                }
+                                .buttonStyle(.borderedProminent)
                             }
-                            .buttonStyle(.borderedProminent)
+                            HabitCalendarView(completionDates: tracker.completionDates(for: habit))
                         }
+                        .padding(.vertical, 4)
                     }
                 }
+                .listStyle(.plain)
             }
             .padding()
             .navigationTitle("Positive Habits")
+            .onAppear {
+                tracker.fetchHabits { _ in
+                    tracker.fetchAllRecords { _ in }
+                }
+            }
         }
     }
 }

--- a/Widgeme/Widgeme/HabitCalendarView.swift
+++ b/Widgeme/Widgeme/HabitCalendarView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// A small calendar-like grid showing the last four weeks of completions.
+struct HabitCalendarView: View {
+    /// Dates the habit was completed.
+    let completionDates: [Date]
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 7)
+
+    /// The range of days displayed by the grid.
+    private var days: [Date] {
+        let today = Calendar.current.startOfDay(for: Date())
+        // Display the previous 27 days plus today (four weeks)
+        let start = Calendar.current.date(byAdding: .day, value: -27, to: today) ?? today
+        return (0..<28).compactMap { Calendar.current.date(byAdding: .day, value: $0, to: start) }
+    }
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 4) {
+            ForEach(days, id: \.self) { day in
+                let done = completionDates.contains { Calendar.current.isDate($0, inSameDayAs: day) }
+                Circle()
+                    .foregroundColor(done ? .green : .gray.opacity(0.3))
+                    .frame(width: 12, height: 12)
+            }
+        }
+    }
+}
+
+#Preview {
+    HabitCalendarView(completionDates: [])
+}
+


### PR DESCRIPTION
## Summary
- add a calendar-style view using circles for the last four weeks of habit completions
- display this grid for each habit in the main list
- load all existing habit records so every habit has its own grid

## Testing
- `swift test` *(fails: `Could not find Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_e_684a1b9b77a88326a979286e91262bcb