### PR TITLE
Add Habit Completion Count widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Widgeme
 
-This project is a simple SwiftUI application showcasing two widgets. The first
+This project is a simple SwiftUI application showcasing multiple widgets. The first
 widget counts down the days left in the year. A second "Habit Progress" widget
-displays your positive habit completions for the current week. The app also
+displays your positive habit completions for the current week. A third "Habit Totals"
+widget shows how many days you've completed each habit overall. The app also
 includes a small `HabitTracker` class which can store daily check‑ins using
 CloudKit.
 
@@ -11,7 +12,8 @@ CloudKit.
 The `DaysLeftWidget` displays the remaining days in the current year and
 refreshes automatically every day. The `HabitProgressWidget` shows a single
 habit with checkmarks for the last seven days so you can glance at your recent
-streaks right from the home screen.
+streaks right from the home screen. The `HabitCompletionCountWidget` lists your
+habits with the total number of days you've marked them complete.
 
 ### Habit Tracking
 

--- a/Widgeme/WidgemeWidget/DaysLeftWidget.swift
+++ b/Widgeme/WidgemeWidget/DaysLeftWidget.swift
@@ -54,5 +54,6 @@ struct WidgemeWidgetBundle: WidgetBundle {
     var body: some Widget {
         DaysLeftWidget()
         HabitProgressWidget()
+        HabitCompletionCountWidget()
     }
 }

--- a/Widgeme/WidgemeWidget/HabitCompletionCountWidget.swift
+++ b/Widgeme/WidgemeWidget/HabitCompletionCountWidget.swift
@@ -1,0 +1,72 @@
+import WidgetKit
+import SwiftUI
+import CloudKit
+import Widgeme
+
+struct HabitCount: Identifiable {
+    let id = UUID()
+    let name: String
+    let count: Int
+}
+
+struct HabitCompletionCountEntry: TimelineEntry {
+    let date: Date
+    let counts: [HabitCount]
+}
+
+struct HabitCompletionCountProvider: TimelineProvider {
+    func placeholder(in context: Context) -> HabitCompletionCountEntry {
+        HabitCompletionCountEntry(date: .now, counts: [HabitCount(name: "Meditation", count: 10)])
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (HabitCompletionCountEntry) -> Void) {
+        completion(placeholder(in: context))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<HabitCompletionCountEntry>) -> Void) {
+        let tracker = HabitTracker()
+        tracker.fetchHabits { habits in
+            tracker.fetchAllRecords { records in
+                let counts = habits.map { habit in
+                    let total = records.filter { $0.habitID == habit.id && $0.completed }.count
+                    return HabitCount(name: habit.name, count: total)
+                }
+                let entry = HabitCompletionCountEntry(date: .now, counts: counts)
+                let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: .now) ?? .now
+                completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+            }
+        }
+    }
+}
+
+struct HabitCompletionCountWidgetEntryView: View {
+    var entry: HabitCompletionCountProvider.Entry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(entry.counts.prefix(3)) { item in
+                HStack {
+                    Text(item.name)
+                        .font(.headline)
+                    Spacer()
+                    Text("\(item.count)")
+                        .bold()
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+struct HabitCompletionCountWidget: Widget {
+    let kind = "HabitCompletionCountWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: HabitCompletionCountProvider()) { entry in
+            HabitCompletionCountWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Habit Totals")
+        .description("Shows how many days you've completed each habit.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}


### PR DESCRIPTION
## Summary
- show total habit completions with `HabitCompletionCountWidget`
- register the new widget in the widget bundle
- document the new widget in the README

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684a1e338ddc832685c195e964d2735e