### PR TITLE
Add habit streak tracking and widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project is a simple SwiftUI application showcasing multiple widgets. The first
 widget counts down the days left in the year. A second "Habit Progress" widget
 displays your positive habit completions for the current week. A third "Habit Totals"
-widget shows how many days you've completed each habit overall. The app also
+widget shows how many days you've completed each habit overall. A fourth "Habit Streak" widget displays your current streak. The app also
 includes a small `HabitTracker` class which can store daily check‑ins using
 CloudKit.
 
@@ -13,14 +13,14 @@ The `DaysLeftWidget` displays the remaining days in the current year and
 refreshes automatically every day. The `HabitProgressWidget` shows a single
 habit with checkmarks for the last seven days so you can glance at your recent
 streaks right from the home screen. The `HabitCompletionCountWidget` lists your
-habits with the total number of days you've marked them complete.
+habits with the total number of days you've marked them complete. The `HabitStreakWidget` shows your current streak for one habit.
 
 ### Habit Tracking
 
 `HabitTracker` provides a starting point for storing completed days in
 CloudKit. You can now add custom habits and mark each one complete for the
 current day. Each check-in is saved to CloudKit so your progress syncs across
-devices.
+devices. It can now calculate your current and longest streaks for each habit.
 
 This repository only contains the Swift source files. You may need to open the
 `Widgeme.xcodeproj` in Xcode and add a widget extension target to build the

--- a/Widgeme/Widgeme/HabitTracker.swift
+++ b/Widgeme/Widgeme/HabitTracker.swift
@@ -105,4 +105,43 @@ class HabitTracker: ObservableObject {
     func completionDates(for habit: PositiveHabit) -> [Date] {
         records.filter { $0.habitID == habit.id && $0.completed }.map { $0.date }
     }
+
+    /// Returns the current consecutive-day streak for the habit up to today.
+    func currentStreak(for habit: PositiveHabit) -> Int {
+        let completions = completionDates(for: habit)
+            .map { Calendar.current.startOfDay(for: $0) }
+            .sorted(by: >)
+        var streak = 0
+        var day = Calendar.current.startOfDay(for: Date())
+        for date in completions {
+            if Calendar.current.isDate(date, inSameDayAs: day) {
+                streak += 1
+                day = Calendar.current.date(byAdding: .day, value: -1, to: day)!
+            } else if date < day {
+                break
+            }
+        }
+        return streak
+    }
+
+    /// Returns the longest streak of consecutive completions for the habit.
+    func longestStreak(for habit: PositiveHabit) -> Int {
+        let dates = completionDates(for: habit)
+            .map { Calendar.current.startOfDay(for: $0) }
+            .sorted()
+        var longest = 0
+        var current = 0
+        var previous: Date?
+        for date in dates {
+            if let prev = previous,
+               Calendar.current.dateComponents([.day], from: prev, to: date).day == 1 {
+                current += 1
+            } else {
+                current = 1
+            }
+            longest = max(longest, current)
+            previous = date
+        }
+        return longest
+    }
 }

--- a/Widgeme/WidgemeWidget/DaysLeftWidget.swift
+++ b/Widgeme/WidgemeWidget/DaysLeftWidget.swift
@@ -55,5 +55,6 @@ struct WidgemeWidgetBundle: WidgetBundle {
         DaysLeftWidget()
         HabitProgressWidget()
         HabitCompletionCountWidget()
+        HabitStreakWidget()
     }
 }

--- a/Widgeme/WidgemeWidget/HabitStreakWidget.swift
+++ b/Widgeme/WidgemeWidget/HabitStreakWidget.swift
@@ -1,0 +1,63 @@
+import WidgetKit
+import SwiftUI
+import CloudKit
+import Widgeme
+
+struct HabitStreakEntry: TimelineEntry {
+    let date: Date
+    let habitName: String
+    let streak: Int
+}
+
+struct HabitStreakProvider: TimelineProvider {
+    func placeholder(in context: Context) -> HabitStreakEntry {
+        HabitStreakEntry(date: .now, habitName: "Meditation", streak: 3)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (HabitStreakEntry) -> Void) {
+        completion(placeholder(in: context))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<HabitStreakEntry>) -> Void) {
+        let tracker = HabitTracker()
+        tracker.fetchHabits { habits in
+            guard let habit = habits.first else {
+                completion(Timeline(entries: [placeholder(in: context)], policy: .never))
+                return
+            }
+            tracker.fetchRecords(for: habit) { _ in
+                let streak = tracker.currentStreak(for: habit)
+                let entry = HabitStreakEntry(date: .now, habitName: habit.name, streak: streak)
+                let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: .now) ?? .now
+                completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+            }
+        }
+    }
+}
+
+struct HabitStreakWidgetEntryView: View {
+    var entry: HabitStreakProvider.Entry
+
+    var body: some View {
+        VStack {
+            Text(entry.habitName)
+                .font(.headline)
+            Text("Streak: \(entry.streak)")
+                .font(.title)
+        }
+        .padding()
+    }
+}
+
+struct HabitStreakWidget: Widget {
+    let kind = "HabitStreakWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: HabitStreakProvider()) { entry in
+            HabitStreakWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Habit Streak")
+        .description("Shows your current streak for a habit.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}


### PR DESCRIPTION
## Summary
- track current and longest streaks in `HabitTracker`
- new `HabitStreakWidget` to show today's streak
- expose new widget from `WidgemeWidgetBundle`
- document new widget and streak support in README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684a20ba0a588326a91ba378d7030a6f