### PR TITLE
Enhance app UI with tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,21 @@ widget shows how many days you've completed each habit overall. A fourth "Habit 
 includes a small `HabitTracker` class which can store daily check‑ins using
 CloudKit.
 
+### App UI
+
+The main app now uses a bottom tab bar with separate views for managing your
+habits and viewing summary statistics. Each tab is wrapped in a navigation view
+so the title is displayed at the top while the tab bar provides quick access to
+different sections.
+
 ### Widget
 
 The `DaysLeftWidget` displays the remaining days in the current year and
 refreshes automatically every day. The `HabitProgressWidget` shows a single
 habit with checkmarks for the last seven days so you can glance at your recent
 streaks right from the home screen. The `HabitCompletionCountWidget` lists your
-habits with the total number of days you've marked them complete. The `HabitStreakWidget` shows your current streak for one habit.
+habits with the total number of days you've marked them complete. The
+`HabitStreakWidget` shows your current streak for one habit.
 
 ### Habit Tracking
 

--- a/Widgeme/Widgeme/ContentView.swift
+++ b/Widgeme/Widgeme/ContentView.swift
@@ -10,48 +10,21 @@ import CloudKit
 
 struct ContentView: View {
     @StateObject private var tracker = HabitTracker()
-    @State private var newHabit = ""
 
     var body: some View {
-        NavigationView {
-            VStack(spacing: 16) {
-                Text("\(Date().daysLeftInYear()) days left in the year")
-                    .font(.headline)
-
-                HStack {
-                    TextField("New Habit", text: $newHabit)
-                        .textFieldStyle(.roundedBorder)
-                    Button("Add") {
-                        tracker.addHabit(name: newHabit)
-                        newHabit = ""
-                    }
-                    .disabled(newHabit.isEmpty)
-                }
-
-                List {
-                    ForEach(tracker.habits, id: \.id) { habit in
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack {
-                                Text(habit.name)
-                                Spacer()
-                                Button("Mark Today") {
-                                    tracker.mark(habit: habit, date: Date(), completed: true)
-                                }
-                                .buttonStyle(.borderedProminent)
-                            }
-                            HabitCalendarView(completionDates: tracker.completionDates(for: habit))
-                        }
-                        .padding(.vertical, 4)
-                    }
-                }
-                .listStyle(.plain)
+        TabView {
+            NavigationView {
+                HabitListView(tracker: tracker)
             }
-            .padding()
-            .navigationTitle("Positive Habits")
-            .onAppear {
-                tracker.fetchHabits { _ in
-                    tracker.fetchAllRecords { _ in }
-                }
+            .tabItem {
+                Label("Habits", systemImage: "checkmark.circle")
+            }
+
+            NavigationView {
+                StatsView(tracker: tracker)
+            }
+            .tabItem {
+                Label("Stats", systemImage: "chart.bar")
             }
         }
     }

--- a/Widgeme/Widgeme/HabitListView.swift
+++ b/Widgeme/Widgeme/HabitListView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct HabitListView: View {
+    @ObservedObject var tracker: HabitTracker
+    @State private var newHabit = ""
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("\(Date().daysLeftInYear()) days left in the year")
+                .font(.headline)
+
+            HStack {
+                TextField("New Habit", text: $newHabit)
+                    .textFieldStyle(.roundedBorder)
+                Button("Add") {
+                    tracker.addHabit(name: newHabit)
+                    newHabit = ""
+                }
+                .disabled(newHabit.isEmpty)
+            }
+
+            List {
+                ForEach(tracker.habits, id: \.id) { habit in
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text(habit.name)
+                            Spacer()
+                            Button("Mark Today") {
+                                tracker.mark(habit: habit, date: Date(), completed: true)
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                        HabitCalendarView(completionDates: tracker.completionDates(for: habit))
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .listStyle(.plain)
+        }
+        .padding()
+        .navigationTitle("Positive Habits")
+        .onAppear {
+            tracker.fetchHabits { _ in
+                tracker.fetchAllRecords { _ in }
+            }
+        }
+    }
+}
+
+#Preview {
+    HabitListView(tracker: HabitTracker())
+}

--- a/Widgeme/Widgeme/StatsView.swift
+++ b/Widgeme/Widgeme/StatsView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct StatsView: View {
+    @ObservedObject var tracker: HabitTracker
+
+    var body: some View {
+        List {
+            Section(header: Text("Habits")) {
+                ForEach(tracker.habits, id: \.id) { habit in
+                    let streak = tracker.currentStreak(for: habit)
+                    let longest = tracker.longestStreak(for: habit)
+                    VStack(alignment: .leading) {
+                        Text(habit.name)
+                            .font(.headline)
+                        HStack {
+                            Text("Current Streak: \(streak)")
+                            Spacer()
+                            Text("Longest: \(longest)")
+                        }
+                        .font(.subheadline)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Statistics")
+        .onAppear {
+            tracker.fetchHabits { _ in
+                tracker.fetchAllRecords { _ in }
+            }
+        }
+    }
+}
+
+#Preview {
+    StatsView(tracker: HabitTracker())
+}


### PR DESCRIPTION
## Summary
- split original content view into `HabitListView`
- add new `StatsView` to show streak information
- use a `TabView` with navigation for each section
- document the new tab-based navigation

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684b2883497c8326b367b2f13cc51607