### PR TITLE
Fix tests after pulling old update

### DIFF
--- a/Widgeme/WidgemeTests/WidgemeTests.swift
+++ b/Widgeme/WidgemeTests/WidgemeTests.swift
@@ -5,13 +5,24 @@
 //  Created by Elliot Rapp on 6/11/25.
 //
 
-import Testing
+import XCTest
 @testable import Widgeme
 
-struct WidgemeTests {
+final class WidgemeTests: XCTestCase {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    func testDaysLeftInYearCalculation() {
+        // Use a fixed date to get a predictable result
+        var dateComponents = DateComponents()
+        dateComponents.year = 2025
+        dateComponents.month = 6
+        dateComponents.day = 15
+        let calendar = Calendar.current
+        let testDate = calendar.date(from: dateComponents)!
+
+        let daysLeft = testDate.daysLeftInYear()
+
+        // There are 199 days left in 2025 after June 15th
+        XCTAssertEqual(daysLeft, 199)
     }
 
 }


### PR DESCRIPTION
## Summary
- fix tests to compile by replacing custom Testing macros with XCTest

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684b2c18fd9883268a046a7882098961