### PR TITLE
Fix tests after pulling old update

### DIFF
--- a/Widgeme/Widgeme/HabitListView.swift
+++ b/Widgeme/Widgeme/HabitListView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct HabitListView: View {
     @ObservedObject var tracker: HabitTracker
     @State private var newHabit = ""
+    @State private var editingHabit: PositiveHabit?
+    @State private var editedName = ""
 
     var body: some View {
         VStack(spacing: 16) {
@@ -33,6 +35,20 @@ struct HabitListView: View {
                         HabitCalendarView(completionDates: tracker.completionDates(for: habit))
                     }
                     .padding(.vertical, 4)
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            tracker.deleteHabit(habit)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        Button {
+                            editingHabit = habit
+                            editedName = habit.name
+                        } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
+                        .tint(.blue)
+                    }
                 }
             }
             .listStyle(.plain)
@@ -43,6 +59,32 @@ struct HabitListView: View {
             tracker.fetchHabits { _ in
                 tracker.fetchAllRecords { _ in }
             }
+        }
+        .sheet(item: $editingHabit) { habit in
+            NavigationView {
+                VStack(spacing: 16) {
+                    TextField("Habit Name", text: $editedName)
+                        .textFieldStyle(.roundedBorder)
+                        .padding()
+                    Spacer()
+                }
+                .navigationTitle("Edit Habit")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { editingHabit = nil }
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            if let habit = editingHabit {
+                                tracker.updateHabit(habit, name: editedName)
+                            }
+                            editingHabit = nil
+                        }
+                        .disabled(editedName.isEmpty)
+                    }
+                }
+            }
+            .presentationDetents([.medium])
         }
     }
 }

--- a/Widgeme/WidgemeTests/WidgemeTests.swift
+++ b/Widgeme/WidgemeTests/WidgemeTests.swift
@@ -5,13 +5,24 @@
 //  Created by Elliot Rapp on 6/11/25.
 //
 
-import Testing
+import XCTest
 @testable import Widgeme
 
-struct WidgemeTests {
+final class WidgemeTests: XCTestCase {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    func testDaysLeftInYearCalculation() {
+        // Use a fixed date to get a predictable result
+        var dateComponents = DateComponents()
+        dateComponents.year = 2025
+        dateComponents.month = 6
+        dateComponents.day = 15
+        let calendar = Calendar.current
+        let testDate = calendar.date(from: dateComponents)!
+
+        let daysLeft = testDate.daysLeftInYear()
+
+        // There are 199 days left in 2025 after June 15th
+        XCTAssertEqual(daysLeft, 199)
     }
 
 }


### PR DESCRIPTION
## Summary
- fix tests to compile by replacing custom Testing macros with XCTest
- add habit deletion and editing support

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684b2c18fd9883268a046a7882098961