### PR TITLE
Add habit customization sheet

### DIFF
--- a/Widgeme/Widgeme/AddHabitView.swift
+++ b/Widgeme/Widgeme/AddHabitView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct AddHabitView: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var tracker: HabitTracker
+
+    @State private var name = ""
+    @State private var days = 28
+    @State private var color = "green"
+
+    private let colors = ["red", "orange", "yellow", "green", "blue", "purple"]
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Name")) {
+                    TextField("Habit name", text: $name)
+                }
+                Section(header: Text("Days")) {
+                    Stepper(value: $days, in: 1...90) {
+                        Text("\(days) days")
+                    }
+                }
+                Section(header: Text("Color")) {
+                    Picker("Color", selection: $color) {
+                        ForEach(colors, id: \.self) { option in
+                            Text(option.capitalized).tag(option)
+                                .foregroundColor(Color.from(name: option))
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+            }
+            .navigationTitle("New Habit")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") {
+                        tracker.addHabit(name: name, days: days, colorName: color)
+                        dismiss()
+                    }
+                    .disabled(name.isEmpty)
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+}
+
+#Preview {
+    AddHabitView(tracker: HabitTracker())
+}

--- a/Widgeme/Widgeme/Color+Named.swift
+++ b/Widgeme/Widgeme/Color+Named.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension Color {
+    /// Returns a SwiftUI `Color` from a simple color name.
+    static func from(name: String) -> Color {
+        switch name.lowercased() {
+        case "red": return .red
+        case "orange": return .orange
+        case "yellow": return .yellow
+        case "blue": return .blue
+        case "purple": return .purple
+        default: return .green
+        }
+    }
+}

--- a/Widgeme/Widgeme/ContentView.swift
+++ b/Widgeme/Widgeme/ContentView.swift
@@ -10,7 +10,7 @@ import CloudKit
 
 struct ContentView: View {
     @StateObject private var tracker = HabitTracker()
-    @State private var newHabit = ""
+    @State private var showAddSheet = false
     @State private var editingHabit: PositiveHabit?
     @State private var editedName = ""
     @State private var showCloudAlert = false
@@ -24,16 +24,13 @@ struct ContentView: View {
                         .font(.title2.weight(.semibold))
 
                     HStack {
-                        TextField("New Habit", text: $newHabit)
-                            .textFieldStyle(.roundedBorder)
+                        Spacer()
                         Button {
-                            tracker.addHabit(name: newHabit)
-                            newHabit = ""
+                            showAddSheet = true
                         } label: {
                             Image(systemName: "plus.circle.fill")
                         }
                         .buttonStyle(.borderedProminent)
-                        .disabled(newHabit.isEmpty)
                     }
 
                     List {
@@ -116,6 +113,10 @@ struct ContentView: View {
                 }
             }
             .presentationDetents([.medium])
+        }
+        // Add habit sheet
+        .sheet(isPresented: $showAddSheet) {
+            AddHabitView(tracker: tracker)
         }
         // iCloud alert
         .alert("iCloud Unavailable", isPresented: $showCloudAlert) {

--- a/Widgeme/Widgeme/HabitCalendarView.swift
+++ b/Widgeme/Widgeme/HabitCalendarView.swift
@@ -4,15 +4,18 @@ import SwiftUI
 struct HabitCalendarView: View {
     /// Dates the habit was completed.
     let completionDates: [Date]
+    /// Number of days to display.
+    let totalDays: Int
+    /// Color of the grid cells.
+    let color: Color
 
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 7)
 
     /// The range of days displayed by the grid.
     private var days: [Date] {
         let today = Calendar.current.startOfDay(for: Date())
-        // Display the previous 27 days plus today (four weeks)
-        let start = Calendar.current.date(byAdding: .day, value: -27, to: today) ?? today
-        return (0..<28).compactMap { Calendar.current.date(byAdding: .day, value: $0, to: start) }
+        let start = Calendar.current.date(byAdding: .day, value: -(totalDays - 1), to: today) ?? today
+        return (0..<totalDays).compactMap { Calendar.current.date(byAdding: .day, value: $0, to: start) }
     }
 
     var body: some View {
@@ -20,7 +23,7 @@ struct HabitCalendarView: View {
             ForEach(days, id: \.self) { day in
                 let done = completionDates.contains { Calendar.current.isDate($0, inSameDayAs: day) }
                 Circle()
-                    .foregroundColor(done ? .green : .gray.opacity(0.3))
+                    .foregroundColor(done ? color : color.opacity(0.3))
                     .frame(width: 12, height: 12)
             }
         }
@@ -28,6 +31,6 @@ struct HabitCalendarView: View {
 }
 
 #Preview {
-    HabitCalendarView(completionDates: [])
+    HabitCalendarView(completionDates: [], totalDays: 28, color: .green)
 }
 

--- a/Widgeme/Widgeme/HabitListView.swift
+++ b/Widgeme/Widgeme/HabitListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct HabitListView: View {
     @ObservedObject var tracker: HabitTracker
     @State private var newHabit = ""
+    @State private var showAddSheet = false
     @State private var editingHabit: PositiveHabit?
     @State private var editedName = ""
 
@@ -12,14 +13,13 @@ struct HabitListView: View {
                 .font(.headline)
 
             HStack {
-                TextField("New Habit", text: $newHabit)
-                    .textFieldStyle(.roundedBorder)
-                Button("Add") {
-                    tracker.addHabit(name: newHabit)
-                    newHabit = ""
+                Spacer()
+                Button {
+                    showAddSheet = true
+                } label: {
+                    Label("Add Habit", systemImage: "plus.circle.fill")
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(newHabit.isEmpty)
             }
 
             List {
@@ -33,7 +33,11 @@ struct HabitListView: View {
                             }
                             .buttonStyle(.borderedProminent)
                         }
-                        HabitCalendarView(completionDates: tracker.completionDates(for: habit))
+                        HabitCalendarView(
+                            completionDates: tracker.completionDates(for: habit),
+                            totalDays: habit.days,
+                            color: Color.from(name: habit.colorName)
+                        )
                     }
                     .padding(.vertical, 4)
                     .swipeActions(edge: .trailing) {
@@ -60,6 +64,9 @@ struct HabitListView: View {
             tracker.fetchHabits { _ in
                 tracker.fetchAllRecords { _ in }
             }
+        }
+        .sheet(isPresented: $showAddSheet) {
+            AddHabitView(tracker: tracker)
         }
         .sheet(item: $editingHabit) { habit in
             NavigationView {

--- a/Widgeme/Widgeme/HabitRowView.swift
+++ b/Widgeme/Widgeme/HabitRowView.swift
@@ -7,16 +7,10 @@ struct HabitRowView: View {
 
     private var completions: [Date] {
         let today = Calendar.current.startOfDay(for: Date())
-        let start = Calendar.current.date(byAdding: .day, value: -6, to: today) ?? today
+        let start = Calendar.current.date(byAdding: .day, value: -(habit.days - 1), to: today) ?? today
         return tracker.records
             .filter { $0.habitID == habit.id && $0.completed && $0.date >= start && $0.date <= today }
             .map { Calendar.current.startOfDay(for: $0.date) }
-    }
-
-    private var days: [Date] {
-        let today = Calendar.current.startOfDay(for: Date())
-        let start = Calendar.current.date(byAdding: .day, value: -6, to: today) ?? today
-        return (0..<7).compactMap { Calendar.current.date(byAdding: .day, value: $0, to: start) }
     }
 
     var body: some View {
@@ -33,18 +27,19 @@ struct HabitRowView: View {
                 .buttonStyle(.borderedProminent)
             }
 
-            HStack(spacing: 4) {
-                ForEach(days, id: \.self) { day in
-                    let done = completions.contains { Calendar.current.isDate($0, inSameDayAs: day) }
-                    Image(systemName: done ? "checkmark.circle.fill" : "circle")
-                        .foregroundStyle(done ? .green : .gray)
-                }
-            }
+            HabitCalendarView(
+                completionDates: completions,
+                totalDays: habit.days,
+                color: Color.from(name: habit.colorName)
+            )
         }
         .padding(.vertical, 4)
     }
 }
 
 #Preview {
-    HabitRowView(habit: PositiveHabit(id: CKRecord.ID(recordName: "1"), name: "Test"), tracker: HabitTracker())
+    HabitRowView(
+        habit: PositiveHabit(id: CKRecord.ID(recordName: "1"), name: "Test", days: 28, colorName: "green"),
+        tracker: HabitTracker()
+    )
 }


### PR DESCRIPTION
## Summary
- add simple color helper
- allow specifying days and color when creating habits
- display habits using custom color and day count
- support editing name with new properties preserved
- create sheet for adding habits

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5df76e6883268520bcd705cb24ec