### PR TITLE
Improve HabitCalendar grid order and style

### DIFF
--- a/Widgeme/Widgeme/HabitCalendarView.swift
+++ b/Widgeme/Widgeme/HabitCalendarView.swift
@@ -11,11 +11,12 @@ struct HabitCalendarView: View {
 
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 7)
 
-    /// The range of days displayed by the grid.
+    /// The range of days displayed by the grid ordered from newest to oldest.
     private var days: [Date] {
         let today = Calendar.current.startOfDay(for: Date())
-        let start = Calendar.current.date(byAdding: .day, value: -(totalDays - 1), to: today) ?? today
-        return (0..<totalDays).compactMap { Calendar.current.date(byAdding: .day, value: $0, to: start) }
+        return (0..<totalDays).compactMap { dayOffset in
+            Calendar.current.date(byAdding: .day, value: -dayOffset, to: today)
+        }
     }
 
     var body: some View {
@@ -27,6 +28,11 @@ struct HabitCalendarView: View {
                     .frame(width: 12, height: 12)
             }
         }
+        .padding(6)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(color.opacity(0.3))
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- show most recent day in the first grid cell
- draw HabitCalendar on a rounded rectangle

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684b6079ab1883269c5efd66500673d1